### PR TITLE
Typo: 错别字修正 in docs/约定.md

### DIFF
--- a/docs/约定.md
+++ b/docs/约定.md
@@ -12,7 +12,7 @@
 
 ### 1.1 接口层区分两类：返回数据 + 返回视图
 
-建议：不要讲两类接口放在同一个Controller文件中，分开存放
+建议：不要将两类接口放在同一个Controller文件中，分开存放
 
 - RestController:
     - 返回json/xml/string格式数据，


### PR DESCRIPTION
修复文档中的错别字

在文档的第15行，把 `"不要讲"` 改为 `"不要将"`。

