### PR TITLE
fix:修复前端url错误导致的np异常

### DIFF
--- a/paicoding-ui/src/main/resources/templates/components/layout/navbar.html
+++ b/paicoding-ui/src/main/resources/templates/components/layout/navbar.html
@@ -232,7 +232,7 @@
       function buildConnect(code) {
           const stateTag = document.getElementById('state');
           const codeTag = document.getElementById('code');
-          const subscribeUrl = "/subscribe?id=" + code;
+          const subscribeUrl = "/subscribe?code=" + code;
           const source = new EventSource(subscribeUrl);
           source.onmessage = function (event) {
               let text = event.data;

--- a/paicoding-ui/src/main/resources/templates/views/login/wx.html
+++ b/paicoding-ui/src/main/resources/templates/views/login/wx.html
@@ -44,7 +44,7 @@
 <script th:inline="javascript">
     const stateTag = document.getElementById('state');
     const code = [[${vo.code}]];
-    const subscribeUrl = "/subscribe?id=" + code;
+    const subscribeUrl = "/subscribe?code=" + code;
     const source = new EventSource(subscribeUrl);
     source.onmessage = function (event) {
         text = event.data;


### PR DESCRIPTION
由于修改了后端接口的参数名,而没修改前端请求的参数名,导致的np异常

`2023-04-17 03:15:34,728 [restartedMain] INFO  c.g.p.f.web.QuickForumApplication.run(QuickForumApplication.java:89) - 启动成功，点击进入首页: http://127.0.0.1:8080
2023-04-17 03:15:37,492 [http-nio-8080-exec-1] INFO  o.a.c.c.C.[Tomcat].[localhost].[/].log(DirectJDKLog.java:173) - Initializing Spring DispatcherServlet 'dispatcherServlet'
2023-04-17 03:15:37,493 [http-nio-8080-exec-1] INFO  o.s.web.servlet.DispatcherServlet.initServletBean(FrameworkServlet.java:525) - Initializing Servlet 'dispatcherServlet'
2023-04-17 03:15:37,494 [http-nio-8080-exec-1] INFO  o.s.web.servlet.DispatcherServlet.initServletBean(FrameworkServlet.java:547) - Completed initialization in 1 ms
2023-04-17 03:15:42,285 [http-nio-8080-exec-9] ERROR c.g.p.f.w.g.ForumExceptionHandler.buildToastMsg(ForumExceptionHandler.java:75) - unexpect error! ReqInfoContext.ReqInfo(appKey=null, host=127.0.0.1:8080, path=null, clientIp=172.23.168.249, referer=http://127.0.0.1:8080/article/detail/102, payload=null, userAgent=Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/112.0.0.0 Safari/537.36, session=s-dc033dc4-9078-477c-a11c-fe24460f0494, userId=null, user=null, msgNum=null, seo=null)
java.lang.NullPointerException: null
	at com.google.common.base.Preconditions.checkNotNull(Preconditions.java:889)
	at com.google.common.cache.LocalCache.put(LocalCache.java:4193)
	at com.google.common.cache.LocalCache$LocalManualCache.put(LocalCache.java:4880)
	at com.github.paicoding.forum.web.front.login.QrLoginHelper.subscribe(QrLoginHelper.java:129)
	at com.github.paicoding.forum.web.front.login.view.LoginViewController.subscribe(LoginViewController.java:94)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.springframework.web.method.support.InvocableHandlerMethod.doInvoke(InvocableHandlerMethod.java:205)
	at org.springframework.web.method.support.InvocableHandlerMethod.invokeForRequest(InvocableHandlerMethod.java:150)
	at org.springframework.web.servlet.mvc.method.annotation.ServletInvocableHandlerMethod.invokeAndHandle(ServletInvocableHandlerMethod.java:117)
	at org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter.invokeHandlerMethod(RequestMappingHandlerAdapter.java:895)
	at org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter.handleInternal(RequestMappingHandlerAdapter.java:808)
	at org.springframework.web.servlet.mvc.method.AbstractHandlerMethodAdapter.handle(AbstractHandlerMethodAdapter.java:87)
	at org.springframework.web.servlet.DispatcherServlet.doDispatch(DispatcherServlet.java:1067)
	at org.springframework.web.servlet.DispatcherServlet.doService(DispatcherServlet.java:963)
	at org.springframework.web.servlet.FrameworkServlet.processRequest(FrameworkServlet.java:1006)
	at org.springframework.web.servlet.FrameworkServlet.doGet(FrameworkServlet.java:898)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:645)
	at org.springframework.web.servlet.FrameworkServlet.service(FrameworkServlet.java:883)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:750)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:227)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:162)
	at org.apache.tomcat.websocket.server.WsFilter.doFilter(WsFilter.java:53)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:189)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:162)
	at com.github.paicoding.forum.web.hook.filter.ReqRecordFilter.doFilter(ReqRecordFilter.java:51)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:189)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:162)
	at org.springframework.web.filter.RequestContextFilter.doFilterInternal(RequestContextFilter.java:100)
	at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:117)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:189)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:162)
	at org.springframework.web.filter.FormContentFilter.doFilterInternal(FormContentFilter.java:93)
	at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:117)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:189)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:162)
	at org.springframework.web.filter.CharacterEncodingFilter.doFilterInternal(CharacterEncodingFilter.java:201)
	at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:117)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:189)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:162)
	at org.apache.catalina.core.StandardWrapperValve.invoke(StandardWrapperValve.java:197)
	at org.apache.catalina.core.StandardContextValve.invoke(StandardContextValve.java:97)
	at org.apache.catalina.authenticator.AuthenticatorBase.invoke(AuthenticatorBase.java:541)
	at org.apache.catalina.core.StandardHostValve.invoke(StandardHostValve.java:135)
	at org.apache.catalina.valves.ErrorReportValve.invoke(ErrorReportValve.java:92)
	at org.apache.catalina.core.StandardEngineValve.invoke(StandardEngineValve.java:78)
	at org.apache.catalina.connector.CoyoteAdapter.service(CoyoteAdapter.java:360)
	at org.apache.coyote.http11.Http11Processor.service(Http11Processor.java:399)
	at org.apache.coyote.AbstractProcessorLight.process(AbstractProcessorLight.java:65)
	at org.apache.coyote.AbstractProtocol$ConnectionHandler.process(AbstractProtocol.java:890)
	at org.apache.tomcat.util.net.NioEndpoint$SocketProcessor.doRun(NioEndpoint.java:1787)
	at org.apache.tomcat.util.net.SocketProcessorBase.run(SocketProcessorBase.java:49)
	at org.apache.tomcat.util.threads.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1191)
	at org.apache.tomcat.util.threads.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:659)
	at org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:61)
	at java.lang.Thread.run(Thread.java:750)
2023-04-17 03:15:42,786 [http-nio-8080-exec-7] ERROR c.g.p.f.w.g.ForumExceptionHandler.buildToastMsg(ForumExceptionHandler.java:75) - unexpect error! ReqInfoContext.ReqInfo(appKey=null, host=127.0.0.1:8080, path=null, clientIp=172.23.168.249, referer=http://127.0.0.1:8080/article/detail/102, payload=null, userAgent=Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/112.0.0.0 Safari/537.36, session=s-dc033dc4-9078-477c-a11c-fe24460f0494, userId=null, user=null, msgNum=null, seo=null)`