### PR TITLE
解决端口好被占用，重新选取未被占用端口号失败的bug

### DIFF
--- a/paicoding-core/src/main/java/com/github/paicoding/forum/core/util/SocketUtil.java
+++ b/paicoding-core/src/main/java/com/github/paicoding/forum/core/util/SocketUtil.java
@@ -19,7 +19,7 @@ public class SocketUtil {
      */
     public static boolean isPortAvailable(int port) {
         try {
-            ServerSocket serverSocket = ServerSocketFactory.getDefault().createServerSocket(port, 1, InetAddress.getByName("localhost"));
+            ServerSocket serverSocket = ServerSocketFactory.getDefault().createServerSocket(port, 1);
             serverSocket.close();
             return true;
         } catch (Exception var3) {


### PR DESCRIPTION
在端口已经被占用情况下，ServerSocketFactory.getDefault().createServerSocket(port, 1, InetAddress.getByName("localhost"));这段代码还是会可能创建ServerSocket成功，并不会出现预期报异常的情况。

-----
解决方法：
ServerSocketFactory.getDefault().createServerSocket(port, 1);剔除多余参数InetAddress.getByName("localhost")。当未传入第三个参数时，底层会进行判断
![image](https://github.com/itwanger/paicoding/assets/54162997/3c7dccee-dafc-4c0f-b123-989f891eacd9)

这样实际调用的是InetAddress.anyLocalAddress()获取的是0.0.0.0/0.0.0.0回文地址。这样就能出现预期异常。



