### PR TITLE
基于redis计数器实现的pv/uv相关信息统计实现

### DIFF
--- a/paicoding-api/src/main/java/com/github/paicoding/forum/api/model/enums/site/SiteVisitStatisticsEnum.java
+++ b/paicoding-api/src/main/java/com/github/paicoding/forum/api/model/enums/site/SiteVisitStatisticsEnum.java
@@ -1,0 +1,22 @@
+package com.github.paicoding.forum.api.model.enums.site;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * 站点统计类型枚举
+ *
+ * @author YiHui
+ * @date 2023/8/22
+ */
+@AllArgsConstructor
+@Getter
+public enum SiteVisitStatisticsEnum {
+    PV(1, "浏览量"),
+    UV(2, "独立访客"),
+    VV(3, "访问次数"),
+    ;
+
+    private int type;
+    private String desc;
+}

--- a/paicoding-service/src/main/java/com/github/paicoding/forum/service/sitemap/constants/SitemapConstants.java
+++ b/paicoding-service/src/main/java/com/github/paicoding/forum/service/sitemap/constants/SitemapConstants.java
@@ -1,0 +1,18 @@
+package com.github.paicoding.forum.service.sitemap.constants;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * 站点相关地图
+ *
+ * @author YiHui
+ * @date 2023/8/22
+ */
+public class SitemapConstants {
+    public static final String SITE_VISIT_KEY = "visit_info";
+
+    public static String day(LocalDate day) {
+        return DateTimeFormatter.ofPattern("yyyyMMdd").format(day);
+    }
+}

--- a/paicoding-service/src/main/java/com/github/paicoding/forum/service/sitemap/model/SiteCntVo.java
+++ b/paicoding-service/src/main/java/com/github/paicoding/forum/service/sitemap/model/SiteCntVo.java
@@ -1,0 +1,32 @@
+package com.github.paicoding.forum.service.sitemap.model;
+
+import lombok.Data;
+
+import java.io.Serializable;
+
+/**
+ * 站点计数
+ *
+ * @author YiHui
+ * @date 2023/8/22
+ */
+@Data
+public class SiteCntVo implements Serializable {
+    private static final long serialVersionUID = 8747459624770066661L;
+    /**
+     * 日期
+     */
+    private String day;
+    /**
+     * 路径，全站时，path为null
+     */
+    private String path;
+    /**
+     * 站点page view 点击数
+     */
+    private Integer pv;
+    /**
+     * 站点unique view 点击数
+     */
+    private Integer uv;
+}

--- a/paicoding-service/src/main/java/com/github/paicoding/forum/service/sitemap/service/SitemapService.java
+++ b/paicoding-service/src/main/java/com/github/paicoding/forum/service/sitemap/service/SitemapService.java
@@ -1,6 +1,9 @@
 package com.github.paicoding.forum.service.sitemap.service;
 
+import com.github.paicoding.forum.service.sitemap.model.SiteCntVo;
 import com.github.paicoding.forum.service.sitemap.model.SiteMapVo;
+
+import java.time.LocalDate;
 
 /**
  * @author YiHui
@@ -43,4 +46,13 @@ public interface SitemapService {
      */
     void saveVisitInfo(String visitIp, String path);
 
+
+    /**
+     * 查询站点某一天or总的访问信息
+     *
+     * @param date 日期，为空时，表示查询所有的站点信息
+     * @param path 访问路径，为空时表示查站点信息
+     * @return
+     */
+    SiteCntVo querySiteVisitInfo(LocalDate date, String path);
 }

--- a/paicoding-service/src/main/java/com/github/paicoding/forum/service/sitemap/service/SitemapService.java
+++ b/paicoding-service/src/main/java/com/github/paicoding/forum/service/sitemap/service/SitemapService.java
@@ -33,4 +33,14 @@ public interface SitemapService {
      * @param articleId
      */
     void rmArticle(Long articleId);
+
+
+    /**
+     * 保存用户访问信息
+     *
+     * @param visitIp 访问者ip
+     * @param path    访问的资源路径
+     */
+    void saveVisitInfo(String visitIp, String path);
+
 }

--- a/paicoding-service/src/main/java/com/github/paicoding/forum/service/sitemap/service/SitemapServiceImpl.java
+++ b/paicoding-service/src/main/java/com/github/paicoding/forum/service/sitemap/service/SitemapServiceImpl.java
@@ -7,6 +7,8 @@ import com.github.paicoding.forum.api.model.vo.article.dto.SimpleArticleDTO;
 import com.github.paicoding.forum.core.cache.RedisClient;
 import com.github.paicoding.forum.core.util.DateUtil;
 import com.github.paicoding.forum.service.article.repository.dao.ArticleDao;
+import com.github.paicoding.forum.service.sitemap.constants.SitemapConstants;
+import com.github.paicoding.forum.service.sitemap.model.SiteCntVo;
 import com.github.paicoding.forum.service.sitemap.model.SiteMapVo;
 import com.github.paicoding.forum.service.sitemap.model.SiteUrlVo;
 import lombok.extern.slf4j.Slf4j;
@@ -16,6 +18,8 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
 import javax.annotation.Resource;
+import java.time.LocalDate;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -119,5 +123,111 @@ public class SitemapServiceImpl implements SitemapService {
         log.info("开始刷新sitemap.xml的url地址，避免出现数据不一致问题!");
         refreshSitemap();
         log.info("刷新完成！");
+    }
+
+
+    /**
+     * 保存站点数据模型
+     * <p>
+     * 站点统计hash：
+     * - visit_info:
+     * ---- pv: 站点的总pv
+     * ---- uv: 站点的总uv
+     * ---- pv_path: 站点某个资源的总访问pv
+     * ---- uv_path: 站点某个资源的总访问uv
+     * - visit_info_ip:
+     * ---- pv: 用户访问的站点总次数
+     * ---- path_pv: 用户访问的路径总次数
+     * - visit_info_20230822每日记录, 一个月一条记录
+     * ---- pv: 12  # field = 月日_pv, pv的计数
+     * ---- uv: 5   # field = 月日_uv, uv的计数
+     * ---- pv_path: 2 # 资源的当前访问计数
+     * ---- uv_path: # 资源的当天访问uv
+     * ---- pv_ip: # 用户当天的访问次数
+     * ---- pv_path_ip: # 用户对资源的当天访问次数
+     *
+     * @param visitIp 访问者ip
+     * @param path    访问的资源路径
+     */
+    @Override
+    public void saveVisitInfo(String visitIp, String path) {
+        String globalKey = SitemapConstants.SITE_VISIT_KEY;
+        String day = SitemapConstants.day(LocalDate.now());
+
+        String todayKey = globalKey + "_" + day;
+
+        // 用户的全局访问计数+1
+        Long globalUserVisitCnt = RedisClient.hIncr(globalKey + "_" + visitIp, "pv", 1);
+        // 用户的当日访问计数+1
+        Long todayUserVisitCnt = RedisClient.hIncr(todayKey, "pv_" + visitIp, 1);
+
+        RedisClient.PipelineAction pipelineAction = RedisClient.pipelineAction();
+        if (globalUserVisitCnt == 1) {
+            // 站点新用户
+            // 今日的uv + 1
+            pipelineAction.add(todayKey, "uv"
+                    , (connection, key, field) -> {
+                        connection.hIncrBy(key, field, 1);
+                    });
+            pipelineAction.add(todayKey, "uv_" + path
+                    , (connection, key, field) -> connection.hIncrBy(key, field, 1));
+
+            // 全局站点的uv
+            pipelineAction.add(globalKey, "uv", (connection, key, field) -> connection.hIncrBy(key, field, 1));
+            pipelineAction.add(globalKey, "uv_" + path, (connection, key, field) -> connection.hIncrBy(key, field, 1));
+        } else if (todayUserVisitCnt == 1) {
+            // 判断是今天的首次访问，更新今天的uv+1
+            pipelineAction.add(todayKey, "uv", (connection, key, field) -> connection.hIncrBy(key, field, 1));
+            pipelineAction.add(todayKey, "uv_" + path, (connection, key, field) -> connection.hIncrBy(key, field, 1));
+        }
+
+
+        // 更新pv 以及 用户的path访问信息
+        // 今天的相关信息 pv
+        pipelineAction.add(todayKey, "pv", (connection, key, field) -> connection.hIncrBy(key, field, 1));
+        pipelineAction.add(todayKey, "pv_" + path, (connection, key, field) -> connection.hIncrBy(key, field, 1));
+        pipelineAction.add(todayKey, "pv_" + path + "_" + visitIp, (connection, key, field) -> connection.hIncrBy(key, field, 1));
+
+
+        // 全局的 PV
+        pipelineAction.add(globalKey, "pv", (connection, key, field) -> connection.hIncrBy(key, field, 1));
+        pipelineAction.add(globalKey, "pv" + "_" + path, (connection, key, field) -> connection.hIncrBy(key, field, 1));
+        pipelineAction.add(globalKey + "_" + visitIp, "pv_" + path, (connection, key, field) -> connection.hIncrBy(key, field, 1));
+
+        // 保存访问信息
+        pipelineAction.execute();
+        if (log.isDebugEnabled()) {
+            log.info("用户访问信息更新完成! 当前用户总访问: {}，今日访问: {}", globalUserVisitCnt, todayUserVisitCnt);
+        }
+    }
+
+    /**
+     * 查询站点某一天的访问信息
+     *
+     * @param date 日期，为空时，表示查询所有的站点信息
+     * @param path 访问路径，为空时表示查站点信息
+     * @return
+     */
+    public SiteCntVo querySiteVisitInfo(LocalDate date, String path) {
+        String globalKey = SitemapConstants.SITE_VISIT_KEY;
+        String day = null, todayKey = globalKey;
+        if (date != null) {
+            day = SitemapConstants.day(date);
+            todayKey = globalKey + "_" + day;
+        }
+
+        String pvField = "pv", uvField = "uv";
+        if (path != null) {
+            // 表示查询对应路径的访问信息
+            pvField += "_" + path;
+            uvField += "_" + path;
+        }
+
+        Map<String, Integer> map = RedisClient.hMGet(todayKey, Arrays.asList(pvField, uvField), Integer.class);
+        SiteCntVo siteInfo = new SiteCntVo();
+        siteInfo.setDay(day);
+        siteInfo.setPv(map.getOrDefault(pvField, 0));
+        siteInfo.setUv(map.getOrDefault(uvField, 0));
+        return siteInfo;
     }
 }

--- a/paicoding-ui/src/main/resources/static/css/components/footer.css
+++ b/paicoding-ui/src/main/resources/static/css/components/footer.css
@@ -5,6 +5,7 @@
   justify-content: center;
   background-color: #000;
   color: #fff;
+  flex-direction: column;
 }
 
 .body-404 footer {
@@ -35,4 +36,9 @@
   border-left: none;
   float: right;
   padding-right: 0;
+}
+
+.foot .visit_cnt {
+  color: #e96900;
+  font-size: 1.2em;
 }

--- a/paicoding-ui/src/main/resources/templates/components/layout/footer.html
+++ b/paicoding-ui/src/main/resources/templates/components/layout/footer.html
@@ -2,16 +2,23 @@
 <html lang="zh-CN" xmlns:th="http://www.thymeleaf.org">
   <footer th:fragment="footer" class="footer-wrap">
     <div class="foot">
-      <a class="text-reset" href="https://beian.miit.gov.cn" target="_blank">
-        <span th:text="${global.siteInfo.websiteRecord}">鄂ICP备18017282号</span>
-      </a>
-      <a class="text-reset"
-        href="https://paicoding.com"
-        th:text="'© 2022-' + ${#dates.format(#dates.createNow(), 'yyyy')} + ' 技术派 '"
-        target="_blank">
-        © 2016-2023 技术派
-      </a>
-      <span th:text="' | ' + ${global.onlineCnt} + ' 人在线'"></span>
+      <div>
+        <a class="text-reset" href="https://beian.miit.gov.cn" target="_blank">
+          <span th:text="${global.siteInfo.websiteRecord}">鄂ICP备18017282号</span>
+        </a>
+        <a class="text-reset"
+          href="https://paicoding.com"
+          th:text="'© 2022-' + ${#dates.format(#dates.createNow(), 'yyyy')} + ' 技术派 '"
+          target="_blank">
+          © 2016-2023 技术派
+        </a>
+        <span th:text="' | ' + ${global.onlineCnt} + ' 人在线'"></span>
+      </div>
+      <div>本站总pv: <span class="visit_cnt" th:text="${global.siteStatisticInfo.pv}">957810</span> &nbsp;
+        | 总uv: <span class="visit_cnt" th:text="${global.siteStatisticInfo.uv}">153147</span> &nbsp; |
+        今日本站pv: <span class="visit_cnt" th:text="${global.todaySiteStatisticInfo.pv}">957810</span> &nbsp;|
+        uv: <span class="visit_cnt" th:text="${global.todaySiteStatisticInfo.uv}">153147</span>
+      </div>
     </div>
   </footer>
 </html>

--- a/paicoding-web/src/main/java/com/github/paicoding/forum/web/global/GlobalInitService.java
+++ b/paicoding-web/src/main/java/com/github/paicoding/forum/web/global/GlobalInitService.java
@@ -8,6 +8,7 @@ import com.github.paicoding.forum.api.model.vo.user.dto.BaseUserInfoDTO;
 import com.github.paicoding.forum.core.util.NumUtil;
 import com.github.paicoding.forum.core.util.SessionUtil;
 import com.github.paicoding.forum.service.notify.service.NotifyService;
+import com.github.paicoding.forum.service.sitemap.service.SitemapService;
 import com.github.paicoding.forum.service.statistics.service.UserStatisticService;
 import com.github.paicoding.forum.service.user.service.LoginOutService;
 import com.github.paicoding.forum.service.user.service.UserService;
@@ -22,6 +23,7 @@ import org.springframework.web.context.request.ServletRequestAttributes;
 
 import javax.annotation.Resource;
 import javax.servlet.http.HttpServletRequest;
+import java.time.LocalDate;
 import java.util.Optional;
 
 /**
@@ -48,6 +50,9 @@ public class GlobalInitService {
     @Resource
     private UserStatisticService userStatisticService;
 
+    @Resource
+    private SitemapService sitemapService;
+
     /**
      * 全局属性配置
      */
@@ -56,6 +61,8 @@ public class GlobalInitService {
         vo.setEnv(env);
         vo.setSiteInfo(globalViewConfig);
         vo.setOnlineCnt(userStatisticService.getOnlineUserCnt());
+        vo.setSiteStatisticInfo(sitemapService.querySiteVisitInfo(null, null));
+        vo.setTodaySiteStatisticInfo(sitemapService.querySiteVisitInfo(LocalDate.now(), null));
 
         if (ReqInfoContext.getReqInfo() == null || ReqInfoContext.getReqInfo().getSeo() == null || CollectionUtils.isEmpty(ReqInfoContext.getReqInfo().getSeo().getOgp())) {
             Seo seo = seoInjectService.defaultSeo();
@@ -103,7 +110,7 @@ public class GlobalInitService {
             return;
         }
         Optional.ofNullable(SessionUtil.findCookieByName(request, LoginOutService.SESSION_KEY))
-                        .ifPresent(cookie -> initLoginUser(cookie.getValue(), reqInfo));
+                .ifPresent(cookie -> initLoginUser(cookie.getValue(), reqInfo));
     }
 
     public void initLoginUser(String session, ReqInfoContext.ReqInfo reqInfo) {

--- a/paicoding-web/src/main/java/com/github/paicoding/forum/web/global/vo/GlobalVo.java
+++ b/paicoding-web/src/main/java/com/github/paicoding/forum/web/global/vo/GlobalVo.java
@@ -2,6 +2,7 @@ package com.github.paicoding.forum.web.global.vo;
 
 import com.github.paicoding.forum.api.model.vo.seo.SeoTagVo;
 import com.github.paicoding.forum.api.model.vo.user.dto.BaseUserInfoDTO;
+import com.github.paicoding.forum.service.sitemap.model.SiteCntVo;
 import com.github.paicoding.forum.web.config.GlobalViewConfig;
 import lombok.Data;
 
@@ -17,6 +18,16 @@ public class GlobalVo {
      * 网站相关配置
      */
     private GlobalViewConfig siteInfo;
+    /**
+     * 站点统计信息
+     */
+    private SiteCntVo siteStatisticInfo;
+
+    /**
+     * 今日的站点统计想你洗
+     */
+    private SiteCntVo todaySiteStatisticInfo;
+
     /**
      * 环境
      */

--- a/paicoding-web/src/main/java/com/github/paicoding/forum/web/hook/filter/ReqRecordFilter.java
+++ b/paicoding-web/src/main/java/com/github/paicoding/forum/web/hook/filter/ReqRecordFilter.java
@@ -1,10 +1,13 @@
 package com.github.paicoding.forum.web.hook.filter;
 
 import com.github.paicoding.forum.api.model.context.ReqInfoContext;
+import com.github.paicoding.forum.core.async.AsyncUtil;
 import com.github.paicoding.forum.core.mdc.MdcUtil;
 import com.github.paicoding.forum.core.util.CrossUtil;
 import com.github.paicoding.forum.core.util.IpUtil;
 import com.github.paicoding.forum.core.util.SessionUtil;
+import com.github.paicoding.forum.core.util.SpringUtil;
+import com.github.paicoding.forum.service.sitemap.service.SitemapServiceImpl;
 import com.github.paicoding.forum.service.statistics.service.StatisticsSettingService;
 import com.github.paicoding.forum.service.user.service.LoginOutService;
 import com.github.paicoding.forum.web.global.GlobalInitService;
@@ -110,6 +113,8 @@ public class ReqRecordFilter implements Filter {
             globalInitService.initLoginUser(reqInfo);
             ReqInfoContext.addReqInfo(reqInfo);
 
+            // 更新uv/pv计数
+            AsyncUtil.execute(() -> SpringUtil.getBean(SitemapServiceImpl.class).saveVisitInfo(reqInfo.getClientIp(), reqInfo.getPath()));
             // 返回头中记录traceId
             response.setHeader(GLOBAL_TRACE_ID_HEADER, Optional.ofNullable(MdcUtil.getTraceId()).orElse(""));
         } catch (Exception e) {

--- a/paicoding-web/src/main/java/com/github/paicoding/forum/web/hook/interceptor/GlobalViewInterceptor.java
+++ b/paicoding-web/src/main/java/com/github/paicoding/forum/web/hook/interceptor/GlobalViewInterceptor.java
@@ -7,11 +7,9 @@ import com.github.paicoding.forum.api.model.vo.constants.StatusEnum;
 import com.github.paicoding.forum.core.permission.Permission;
 import com.github.paicoding.forum.core.permission.UserRole;
 import com.github.paicoding.forum.core.util.JsonUtil;
-import com.github.paicoding.forum.core.util.SessionUtil;
 import com.github.paicoding.forum.core.util.SpringUtil;
 import com.github.paicoding.forum.service.rank.service.UserActivityRankService;
 import com.github.paicoding.forum.service.rank.service.model.ActivityScoreBo;
-import com.github.paicoding.forum.service.user.service.LoginOutService;
 import com.github.paicoding.forum.web.global.GlobalInitService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,10 +22,8 @@ import org.springframework.web.method.HandlerMethod;
 import org.springframework.web.servlet.AsyncHandlerInterceptor;
 import org.springframework.web.servlet.ModelAndView;
 
-import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import java.util.UUID;
 
 /**
  * 注入全局的配置信息：
@@ -53,6 +49,7 @@ public class GlobalViewInterceptor implements AsyncHandlerInterceptor {
 
             if (permission == null || permission.role() == UserRole.ALL) {
                 if (ReqInfoContext.getReqInfo() != null) {
+                    // 用户活跃度更新
                     SpringUtil.getBean(UserActivityRankService.class).addActivityScore(ReqInfoContext.getReqInfo().getUserId(), new ActivityScoreBo().setPath(ReqInfoContext.getReqInfo().getPath()));
                 }
                 return true;


### PR DESCRIPTION
基于redis计数器实现pv/uv统计:

* 站点统计hash：
     * - visit_info:
     * ---- pv: 站点的总pv
     * ---- uv: 站点的总uv
     * ---- pv_path: 站点某个资源的总访问pv
     * ---- uv_path: 站点某个资源的总访问uv
     * - visit_info_ip:
     * ---- pv: 用户访问的站点总次数
     * ---- path_pv: 用户访问的路径总次数
     * - visit_info_20230822每日记录, 一个月一条记录
     * ---- pv: 12  # field = 月日_pv, pv的计数
     * ---- uv: 5   # field = 月日_uv, uv的计数
     * ---- pv_path: 2 # 资源的当前访问计数
     * ---- uv_path: # 资源的当天访问uv
     * ---- pv_ip: # 用户当天的访问次数
     * ---- pv_path_ip: # 用户对资源的当天访问次数