### PR TITLE
fix:修复配置为其他数据库名称，脚本初始化失败

### DIFF
--- a/paicoding-web/src/main/resources/liquibase/data/init_data_230821.sql
+++ b/paicoding-web/src/main/resources/liquibase/data/init_data_230821.sql
@@ -1,4 +1,4 @@
-INSERT INTO pai_coding.global_conf (`key`, value, comment, deleted)
+INSERT INTO global_conf (`key`, value, comment, deleted)
 VALUES ('view.site.starInfo', '## 该文档仅「二哥的编程星球」VIP 用户可见
 
 二哥的编程星球内容包括：


### PR DESCRIPTION
当初始化时，数据库配置名称改为其他，初始化sql报错，原因是脚本内写死了数据库名称(pai_coding)导致：INSERT INTO pai_coding.global_conf

