### PR TITLE
修复mdImgReplace中的异步错误问题

### DIFF
--- a/paicoding-core/src/main/java/com/github/paicoding/forum/core/async/AsyncUtil.java
+++ b/paicoding-core/src/main/java/com/github/paicoding/forum/core/async/AsyncUtil.java
@@ -148,7 +148,7 @@ public class AsyncUtil {
             cost = new ConcurrentSkipListMap<>();
             cost.put(task, System.currentTimeMillis());
             this.executorService = TtlExecutors.getTtlExecutorService(executorService);
-            this.markOver = true;
+            this.markOver = false;
         }
 
         /**

--- a/paicoding-service/src/main/java/com/github/paicoding/forum/service/image/service/ImageServiceImpl.java
+++ b/paicoding-service/src/main/java/com/github/paicoding/forum/service/image/service/ImageServiceImpl.java
@@ -149,8 +149,6 @@ public class ImageServiceImpl implements ImageService {
                     imgReplaceMap.put(img, saveImg(img.getUrl()));
                 }, img.getUrl());
             }
-            // 等待所有图片转存完成
-            bridge.allExecuted();
         }
 
         // 图片替换

--- a/paicoding-service/src/main/java/com/github/paicoding/forum/service/image/service/ImageServiceImpl.java
+++ b/paicoding-service/src/main/java/com/github/paicoding/forum/service/image/service/ImageServiceImpl.java
@@ -149,6 +149,8 @@ public class ImageServiceImpl implements ImageService {
                     imgReplaceMap.put(img, saveImg(img.getUrl()));
                 }, img.getUrl());
             }
+            // 等待所有图片转存完成
+            bridge.allExecuted();
         }
 
         // 图片替换

--- a/paicoding-web/src/test/java/com/github/paicoding/forum/test/upload/ImageServiceTest.java
+++ b/paicoding-web/src/test/java/com/github/paicoding/forum/test/upload/ImageServiceTest.java
@@ -25,4 +25,16 @@ public class ImageServiceTest extends BasicTest {
         System.out.println(imageService.saveImg("https://www.baidu.com/img/flexible/logo/pc/peak-result.png"));
     }
 
+    @Test
+    public void testAsyncSaveImage() throws Exception {
+        String content = "这是一段测试的 Markdown 内容，其中包含一张图片。\n" +
+                "![百度logo](https://www.baidu.com/img/flexible/logo/pc/peak-result.png)\n" +
+                "![百度logo](https://www.baidu.com/img/flexible/logo/pc/peak-result.png)\n" +
+                "![百度logo](https://www.baidu.com/img/flexible/logo/pc/peak-result.png)\n" +
+                "图片显示的是百度的 logo。";
+        content = imageService.mdImgReplace(content);
+        System.out.println(content);
+    }
+
+
 }


### PR DESCRIPTION
在原本的代码中，异步计算图像新路径并没有等待任务完成，而是直接进行下一步操作，导致imgReplaceMap其实为空。
加入等待异步完成语句前测试结果：
![0f9eeda1e705f4540f03804dbc8e5f5](https://github.com/user-attachments/assets/d4a0b145-3ba9-4945-a0ca-d22152a11c60)
加入等待异步完成语句后测试结果：
![d099096296ddb4dc0a5ffde71e90e1b](https://github.com/user-attachments/assets/38dbfe6d-0b28-4679-bc99-8ae2658b9259)

