### PR TITLE
fix:修复FastExcel导出Excel不是技术派.xlsx的问题

### DIFF
--- a/paicoding-web/src/main/java/com/github/paicoding/forum/web/admin/rest/StatisticsSettingRestController.java
+++ b/paicoding-web/src/main/java/com/github/paicoding/forum/web/admin/rest/StatisticsSettingRestController.java
@@ -53,11 +53,11 @@ public class StatisticsSettingRestController {
     @GetMapping("pvUvDayDownload2Excel")
     public void pvUvDayDownload2Excel(@RequestParam(name = "day", required = false) Integer day,
                                       HttpServletResponse response) throws IOException {
+        response.reset();
         response.setContentType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
         response.setCharacterEncoding("utf-8");
         String fileName = URLEncoder.encode("技术派", "UTF-8").replaceAll("\\+", "%20");
         response.setHeader("Content-disposition", "attachment;filename*=utf-8''" + fileName + ".xlsx");
-        response.reset();
 
         // 获取数据
         day = (day == null || day == 0) ? DEFAULT_DAY : day;


### PR DESCRIPTION
技术派中`response.reset()`会清除缓冲区中已设置的内容和响应头，导致导出的 Excel 文件名为 “paicoding.xlsx”，而不是 “技术派.xlsx”