### PR TITLE
fix: 添加事务和悲观锁解决UserFootServiceImpl并发控制问题

### DIFF
--- a/paicoding-service/src/main/java/com/github/paicoding/forum/service/user/repository/dao/UserFootDao.java
+++ b/paicoding-service/src/main/java/com/github/paicoding/forum/service/user/repository/dao/UserFootDao.java
@@ -96,6 +96,22 @@ public class UserFootDao extends ServiceImpl<UserFootMapper, UserFootDO> {
 
     public UserFootStatisticDTO getFootCount() {
         return baseMapper.getFootCount();
+    }
 
+    /**
+     * 使用并发操作的悲观锁获取用户足迹
+     *
+     * @param documentId
+     * @param type
+     * @param userId
+     * @return
+     */
+    public UserFootDO getByDocumentAndUserIdWithLock(Long documentId, Integer type, Long userId) {
+        return lambdaQuery()
+                .eq(UserFootDO::getDocumentId, documentId)
+                .eq(UserFootDO::getDocumentType, type)
+                .eq(UserFootDO::getUserId, userId)
+                .last("FOR UPDATE")
+                .one();
     }
 }


### PR DESCRIPTION
# 问题修复：UserFootServiceImpl 中并发控制问题

## 解决方案
使用**事务 + 悲观锁**确保对同一记录的并发操作的原子性和一致性。

## 修改内容
- 在 `UserFootDao` 中新增 `getByDocumentAndUserIdWithLock` 方法，使用 `select for update` 实现悲观锁
- 在 `saveOrUpdateUserFoot` 和 `favorArticleComment` 方法上添加 `@Transactional` 注解实现事务控制
- 删除了没有用到的 `ResVo` 导入
- 移除了相关 fixme 注释

实现方案参照项目中 `ArticlePayServiceImpl` 的实现风格，使用相同的悲观锁模式，通过 MyBatis-Plus 的链式调用，使代码更简洁高效。这些修改确保在高并发场景下保持数据一致性。

## 主要修改如下：
- `UserFootDao`：
<img width="1098" alt="image" src="https://github.com/user-attachments/assets/c974f833-1212-42be-ab53-4411face82a9" />
- `favorArticleComment`：
<img width="1339" alt="image" src="https://github.com/user-attachments/assets/ef45b041-2816-4f17-878d-f5083d9f63d4" />
- `saveOrUpdateUserFoot` 同 `favorArticleComment` 一样