### PR TITLE
Close OutputStream in run

### DIFF
--- a/paicoding-web/src/main/java/com/github/paicoding/forum/web/javabetter/top/image/Convert.java
+++ b/paicoding-web/src/main/java/com/github/paicoding/forum/web/javabetter/top/image/Convert.java
@@ -52,11 +52,12 @@ public class Convert {
         public void run() {
             URL url = new URL(originImgUrl);
             InputStream inputStream = url.openStream();
-            OutputStream outputStream = new FileOutputStream(destinationImgPath);
-            byte[] buffer = new byte[2048];
-            int length = 0;
-            while ((length = inputStream.read(buffer)) != -1) {
-                outputStream.write(buffer, 0, length);
+            try (OutputStream outputStream = new FileOutputStream(destinationImgPath)) {
+                            byte[] buffer = new byte[2048];
+                            int length = 0;
+                            while ((length = inputStream.read(buffer)) != -1) {
+                                outputStream.write(buffer, 0, length);
+                            }
             }
         }
     }


### PR DESCRIPTION
The behavior in run might be relying on something a little implicit. The resource opened there can leak if run exits on an error path. this patch moves the allocation into try-with-resources so cleanup happens on every exit path. Sorry if this is intentional.

Happy to revise the approach or close this if it doesn’t fit — you know the codebase far better than I do.